### PR TITLE
[Release (1.6.0)] Clone Songs Resource

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "playliter-backend",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "private": true,
   "author": {
     "name": "Gabriel Mazurco",

--- a/src/data/protocols/show/commands/clone-concert.command.impl.ts
+++ b/src/data/protocols/show/commands/clone-concert.command.impl.ts
@@ -1,0 +1,17 @@
+// Dependencies
+import { ICommand } from '@nestjs/cqrs'
+
+// Domain Protocols
+import { CloneConcertInput } from '@/domain/protocols'
+
+// Data Protocols
+import { TokenPayload } from '@/data/protocols'
+
+// Link song command
+export class CloneConcertCommand implements ICommand {
+  constructor(
+    public readonly showId: string,
+    public readonly params: CloneConcertInput,
+    public readonly payload: TokenPayload
+  ) {}
+}

--- a/src/data/protocols/show/commands/index.ts
+++ b/src/data/protocols/show/commands/index.ts
@@ -1,5 +1,6 @@
 export * from './add-observation.command.impl'
 export * from './add-show.command.impl'
+export * from './clone-concert.command.impl'
 export * from './link-song.command.impl'
 export * from './remove-observation.command.impl'
 export * from './remove-show.command.impl'

--- a/src/data/usecases/show/commands/clone-concert.command.handler.ts
+++ b/src/data/usecases/show/commands/clone-concert.command.handler.ts
@@ -1,0 +1,108 @@
+// Dependencies
+import { HttpException, HttpStatus, Inject } from '@nestjs/common'
+import { CommandHandler, ICommandHandler } from '@nestjs/cqrs'
+
+// Commands
+import { CloneConcertCommand } from '@/data/protocols'
+
+// Repositories and Schemas
+import { BandRepository, AccountRepository, ShowRepository } from '@/infra/db/mongodb'
+
+// Domain Entities
+import { Account, Band, Show } from '@/domain/entities'
+
+// Domain Protocols
+import { RoleEnum } from '@/domain/protocols'
+
+@CommandHandler(CloneConcertCommand)
+export class CloneConcertHandler implements ICommandHandler<CloneConcertCommand> {
+  // Dependencies injection
+  constructor(
+    private readonly showRepository: ShowRepository,
+    @Inject('BandRepository') private readonly bandRepository: BandRepository,
+    @Inject('AccountRepository') private readonly accountRepository: AccountRepository
+  ) {}
+
+  // Execute action handler
+  async execute(command: CloneConcertCommand): Promise<Show> {
+    // Destruct params
+    const { showId, payload: { account } } = command
+
+    // Step 1 - Retrieve account and show
+    const [ currentAccount, currentShow ] = await Promise.all([
+      this.fetchAccount(account),
+      this.fetchShow(command)
+    ])
+    if (!currentAccount) throw new HttpException(
+      `Conta de id ${account} não encontrada`,
+      HttpStatus.NOT_FOUND
+    )
+    if (!currentShow) throw new HttpException(
+      `Apresentação de id ${showId} não encontrada`,
+      HttpStatus.NOT_FOUND
+    )
+
+    // Step 2 - Retrieve band
+    const retrievedBand = await this.fetchBand(currentShow)
+    if (!retrievedBand) throw new HttpException(
+      `Banda não encontrada!`,
+      HttpStatus.NOT_FOUND
+    )
+
+    // Step 3 - Validate Role
+    this.validateRole(command, retrievedBand, currentAccount)
+
+    // Step 4 - Add song to show
+    return await this.cloneShow(command, currentShow)
+  }
+
+  // Fetch account from database
+  async fetchAccount(id: string): Promise<Account | null> {
+    const account = await this.accountRepository.findOne({ id })
+    return account
+  }
+
+  // Fetch band from database
+  async fetchBand(show: Show): Promise<Band | null> {
+    const { band: bandId } = show
+    const band = await this.bandRepository.findOne({ _id: bandId.toString() })
+    return band
+  }
+
+  // Fetch show from database
+  async fetchShow(command: CloneConcertCommand): Promise<Show | null> {
+    const { showId } = command
+    const r = await this.showRepository.findOne({ id: showId })
+    return r
+  }
+
+  // Validates if is user is player
+  validateRole(command: CloneConcertCommand, band: Band, account: Account): void {
+    const { payload: { role } } = command
+    const { owner, admins } = band
+    if (
+      role === RoleEnum.player &&
+      account._id.toString() !== owner &&
+      !admins.includes(account._id.toString())
+    ) {
+      throw new HttpException(
+        `Você não tem permissão como ${RoleEnum.player} para atualizar dados de apresentações dessa banda!`,
+        HttpStatus.FORBIDDEN
+      )
+    }
+  }
+
+  // Clone concert into band
+  async cloneShow(command: CloneConcertCommand, show: Show): Promise<Show | null> {
+    const { params: { date } } = command
+    const { band, description, songs, title } = show
+    const newShow = await this.showRepository.save({
+      band,
+      date: new Date(date),
+      title,
+      description,
+      songs,
+    })
+    return newShow
+  }
+}

--- a/src/data/usecases/show/commands/index.ts
+++ b/src/data/usecases/show/commands/index.ts
@@ -1,5 +1,6 @@
 import { AddObservationHandler  } from './add-observation.command.handler'
 import { AddShowHandler } from './add-show.command.handler'
+import { CloneConcertHandler } from './clone-concert.command.handler'
 import { LinkSongHandler } from './link-song.command.handler'
 import { RemoveObservationHandler } from './remove-observation.command.handler'
 import { RemoveShowHandler } from './remove-show.command.handler'
@@ -11,6 +12,7 @@ import { UpdateShowHandler } from './update-show.command.handler'
 export const ShowCommandHandlers = [
   AddObservationHandler,
   AddShowHandler,
+  CloneConcertHandler,
   LinkSongHandler,
   RemoveObservationHandler,
   RemoveShowHandler,

--- a/src/domain/protocols/show/inputs/clone-concert.input.ts
+++ b/src/domain/protocols/show/inputs/clone-concert.input.ts
@@ -1,0 +1,12 @@
+// Dependencies
+import { IsNotEmpty, IsDateString } from 'class-validator'
+
+// API Documentation
+import { ApiProperty } from '@nestjs/swagger'
+
+export class CloneConcertInput {
+  @IsDateString({}, { message: 'Campo "date" deve ser do formato YYYY-MM-DD' })
+  @IsNotEmpty({ message: 'Campo "date" não deve ser vazio!' })
+  @ApiProperty({ type: String, required: true, example: 'YYYY-MM-DD' })
+  date: string
+}

--- a/src/domain/protocols/show/inputs/index.ts
+++ b/src/domain/protocols/show/inputs/index.ts
@@ -1,5 +1,6 @@
 export * from './add-observation.input'
 export * from './add-show.input'
+export * from './clone-concert.input'
 export * from './link-song.input'
 export * from './list-shows.input'
 export * from './unlink-song.input'

--- a/src/presentation/controllers/show/show.controller.ts
+++ b/src/presentation/controllers/show/show.controller.ts
@@ -14,6 +14,7 @@ import { TokenPayload } from '@/data/protocols'
 import {
   AddObservationInput,
   AddShowInput,
+  CloneConcertInput,
   LinkSongInput,
   ListShowsInput,
   ReorderShowInput,
@@ -142,6 +143,30 @@ export class ShowController {
     @JwtUserDecorator() payload: TokenPayload
   ): Promise<IBaseResponse> {
     return this.showService.addShow(params, payload)
+  }
+
+  /**
+   * Clone show into band
+   * @param params - Desired date
+   * @param payload - Token payload
+   * @returns - Base response containing show
+   */
+  @Post('/:id')
+  @Roles(Role.player, Role.master)
+  @ApiOperation({
+    summary: 'Clone concert',
+    description: 'Duplicates a concert into the same band'
+  })
+  @ApiResponse({
+    status: 201,
+    description: 'Returns the duplicated concert.'
+  })
+  async cloneConcert(
+    @Param('id') id: string,
+    @Body() params: CloneConcertInput,
+    @JwtUserDecorator() payload: TokenPayload
+  ): Promise<IBaseResponse> {
+    return this.showService.cloneConcert(id, params, payload)
   }
 
   /**

--- a/src/presentation/services/show/show.service.ts
+++ b/src/presentation/services/show/show.service.ts
@@ -7,6 +7,7 @@ import { baseResponse, IBaseResponse, sanitizeJson } from '@/domain/shared'
 import {
   AddObservationInput,
   AddShowInput,
+  CloneConcertInput,
   LinkSongInput,
   ListShowsInput,
   ReorderShowInput,
@@ -19,6 +20,7 @@ import {
 import {
   AddObservationCommand,
   AddShowCommand,
+  CloneConcertCommand,
   LinkSongCommand,
   ListShowsQuery,
   ListShowsByAccountQuery,
@@ -96,6 +98,13 @@ export class ShowService {
     const response = await this.commandBus.execute(new AddShowCommand(params, payload))
     const safeResponse = sanitizeJson(response, showMutationOmitKeys)
     return baseResponse(201, 'Show salvo com sucesso!', safeResponse)
+  }
+
+  // Clone show
+  async cloneConcert(id: string, params: CloneConcertInput, payload: TokenPayload): Promise<IBaseResponse> {
+    const response = await this.commandBus.execute(new CloneConcertCommand(id, params, payload))
+    const safeResponse = sanitizeJson(response, showMutationOmitKeys)
+    return baseResponse(200, 'Apresentação duplicada com sucesso!', safeResponse)
   }
 
   // Add show observation


### PR DESCRIPTION
# Description

Build for playliter API version **1.6.0**

## Changes

* Added clone show endpoint to API.

## Endpoints

Added endpoints:

### Clone show

Method: POST
Path: /shows/:id
Body:
```json
{
    "date": "YYYY-MM-DD"
}
```
Authorization: JWT required