### PR TITLE
[Release(1.6.2)] Adding v2 version to list endpoints

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "playliter-backend",
-  "version": "1.6.1",
+  "version": "1.6.2",
   "private": true,
   "author": {
     "name": "Gabriel Mazurco",

--- a/src/infra/db/mongodb/show/repositories/show-repository.ts
+++ b/src/infra/db/mongodb/show/repositories/show-repository.ts
@@ -145,4 +145,8 @@ export class ShowRepository implements IShowRepository {
       throw new MongoError({ ...ex })
     }
   }
+
+  async countByBand(bandId: string): Promise<number> {
+    return await this.connection.countDocuments({ band: bandId })
+  }
 }

--- a/src/infra/db/mongodb/song/repositories/category-repository.ts
+++ b/src/infra/db/mongodb/song/repositories/category-repository.ts
@@ -82,4 +82,8 @@ export class CategoryRepository implements ICategoryRepository {
       throw new MongoError({ ...ex })
     }
   }
+
+  async countByBand(bandId: string): Promise<number> {
+    return await this.connection.countDocuments({ band: bandId })
+  }
 }

--- a/src/presentation/controllers/index.ts
+++ b/src/presentation/controllers/index.ts
@@ -2,12 +2,12 @@ import { AccountController } from './account'
 import { AuthController } from './auth'
 import { BandController, InviteController } from './band'
 import { HelperController } from './helper'
-import { ShowController } from './show'
-import { CategoryController, SongController } from './song'
+import { ShowController, ShowControllerV2 } from './show'
+import { CategoryController, CategoryControllerV2, SongController } from './song'
 
 export const AccountControllers = [ AccountController ]
 export const AuthControllers = [ AuthController ]
 export const BandControllers = [ BandController, InviteController ]
 export const HelperControllers = [ HelperController ]
-export const ShowControllers = [ ShowController ]
-export const SongControllers = [ CategoryController, SongController ]
+export const ShowControllers = [ ShowController, ShowControllerV2 ]
+export const SongControllers = [ CategoryController, CategoryControllerV2, SongController ]

--- a/src/presentation/controllers/show/show.controller.ts
+++ b/src/presentation/controllers/show/show.controller.ts
@@ -23,6 +23,41 @@ import {
   UpdateShowInput
 } from '@/domain/protocols'
 
+@ApiTags('Shows V2')
+@Controller('api/v2/shows')
+@Injectable()
+export class ShowControllerV2 {
+  // Dependencies Injection
+  constructor(
+    private readonly showService: ShowService
+  ) {}
+
+  /**
+   * List shows
+   * @param bandId - Band id
+   * @param params - Filters
+   * @param payload - Token payloads
+   * @returns - Base response containing shows
+   */
+  @Get('/list/:bandId')
+  @Roles(Role.player, Role.master)
+  @ApiOperation({
+    summary: 'List band shows',
+    description: 'List all shows from a band'
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Returns a list of shows.'
+  })
+  async listShows(
+    @Param('bandId') bandId: string,
+    @Query() params: ListShowsInput,
+    @JwtUserDecorator() payload: TokenPayload
+  ): Promise<IBaseResponse> {
+    return this.showService.listShowsV2(bandId, params, payload)
+  }
+}
+
 @ApiTags('Shows')
 @Controller('api/v1/shows')
 @Injectable()

--- a/src/presentation/controllers/song/category.controller.ts
+++ b/src/presentation/controllers/song/category.controller.ts
@@ -17,6 +17,41 @@ import {
   ListCategoriesInput
 } from '@/domain/protocols'
 
+@ApiTags('Categories V2')
+@Controller('api/v2/categories')
+@Injectable()
+export class CategoryControllerV2 {
+  // Dependencies Injection
+  constructor(
+    private readonly categoryService: CategoryService
+  ) {}
+
+  /**
+   * List all categories from band
+   * @param bandId - Band id 
+   * @param params - Filter 
+   * @param payload - Token payload
+   * @returns - Base response containing categories
+   */
+  @Get('/get/:bandId')
+  @Roles(Role.player, Role.master)
+  @ApiOperation({
+    summary: 'List categories',
+    description: 'List categories from a band'
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Returns a list of categories.'
+  })
+  async categories(
+    @Param('bandId') bandId: string,
+    @Query() params: ListCategoriesInput,
+    @JwtUserDecorator() payload: TokenPayload
+  ): Promise<IBaseResponse> {
+    return this.categoryService.listCategoriesV2(bandId, params, payload)
+  }
+}
+
 @ApiTags('Categories')
 @Controller('api/v1/categories')
 @Injectable()

--- a/src/presentation/services/show/show.service.ts
+++ b/src/presentation/services/show/show.service.ts
@@ -89,7 +89,19 @@ export class ShowService {
   // List shows
   async listShows(bandId: string, params: ListShowsInput, payload: TokenPayload): Promise<IBaseResponse> {
     const response = await this.queryBus.execute(new ListShowsQuery(bandId, params, payload))
-    const safeResponse = sanitizeJson(response, showOmitKeys)
+    const safeResponse = sanitizeJson(response.data, showOmitKeys)
+    return baseResponse(200, 'Shows recuperados com sucesso!', safeResponse)
+  }
+
+  // List shows (v2)
+  async listShowsV2(bandId: string, params: ListShowsInput, payload: TokenPayload): Promise<IBaseResponse> {
+    const response = await this.queryBus.execute(new ListShowsQuery(bandId, params, payload))
+    const safeResponse = {
+      limit: response.limit,
+      offset: response.offset,
+      total: response.total,
+      data: sanitizeJson(response.data, showOmitKeys)
+    }
     return baseResponse(200, 'Shows recuperados com sucesso!', safeResponse)
   }
 

--- a/src/presentation/services/song/category.service.ts
+++ b/src/presentation/services/song/category.service.ts
@@ -55,7 +55,19 @@ export class CategoryService {
   // List Categories
   async listCategories(bandId: string, params: ListCategoriesInput, payload: TokenPayload): Promise<IBaseResponse> {
     const response = await this.queryBus.execute(new ListCategoriesQuery(bandId, params, payload))
-    const safeResponse = sanitizeJson(response, categoryOmitKeys)
+    const safeResponse = sanitizeJson(response.data, categoryOmitKeys)
+    return baseResponse(200, 'Categorias recuperadas com sucesso!', safeResponse)
+  }
+
+  // List Categories (V2)
+  async listCategoriesV2(bandId: string, params: ListCategoriesInput, payload: TokenPayload): Promise<IBaseResponse> {
+    const response = await this.queryBus.execute(new ListCategoriesQuery(bandId, params, payload))
+    const safeResponse = {
+      limit: response.limit,
+      offset: response.offset,
+      total: response.total,
+      data: sanitizeJson(response.data, categoryOmitKeys)
+    }
     return baseResponse(200, 'Categorias recuperadas com sucesso!', safeResponse)
   }
 


### PR DESCRIPTION
# Description

A small update was needed for the native layout of playliter. This adds v2 endpoints for **Categories** and **Concerts** listing.

Now the returned json is similar to the songs one:

```json
{
    "status": {
        "code": 200,
        "message": "Músicas recuperadas com sucesso!"
    },
    "data": {
        "limit": 0,
        "offset": 0,
        "total": 142,
        "data": []
    }
}
```